### PR TITLE
place missing brace

### DIFF
--- a/hdathesis.sty
+++ b/hdathesis.sty
@@ -55,7 +55,7 @@
  \newtheorem{Corollary}{Corollary}
 }
 \theoremstyle{plain} {{\theorembodyfont{\normalfont}
-\newtheorem{Definition}{Definition}}
+\newtheorem{Definition}{Definition}}}
 \newcommand{\qed}{\hfill \mbox{\raggedright \rule{.07in}{.1in}}}
 \newenvironment{proof}{\vspace{1ex}\noindent{\textbf Proof}\hspace{0.5em}}
 	{\hfill\qed\vspace{2ex}}


### PR DESCRIPTION
Add the missing curly brace, to fix errors/warnings in MiKTeX' pdflatex on windows.